### PR TITLE
Fixed setting and clearing of msgbuf

### DIFF
--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -1005,7 +1005,7 @@ INT8U MCP_CAN::setMsg(INT32U id, INT8U rtr, INT8U ext, INT8U len, INT8U *pData)
     m_nRtr    = rtr;
     m_nExtFlg = ext;
     m_nDlc    = len;
-    for(i = 0; i<MAX_CHAR_IN_MESSAGE; i++)
+    for(i = 0; i<m_nDlc; i++)
         m_nDta[i] = *(pData+i);
 	
     return MCP2515_OK;
@@ -1022,7 +1022,7 @@ INT8U MCP_CAN::clearMsg()
     m_nExtFlg   = 0;
     m_nRtr      = 0;
     m_nfilhit   = 0;
-    for(int i = 0; i<m_nDlc; i++ )
+    for(int i = 0; i<MAX_CHAR_IN_MESSAGE; i++ )
       m_nDta[i] = 0x00;
 
     return MCP2515_OK;


### PR DESCRIPTION
setMsg() and clearMsg() mixed end-condition of for-loop to fill msg buffer